### PR TITLE
Feature/fix hand baselink inertia

### DIFF
--- a/robots/hand_v4/hand_v4.xml
+++ b/robots/hand_v4/hand_v4.xml
@@ -42,6 +42,7 @@
     <geom name="ground" type="plane" size="0 0 1" pos="0.001 0 0" quat="1 0 0 0" material="matplane" condim="1" conaffinity='15'/>
 
     <body name="hand/base_link" childclass="hand" pos="0 0 0.5" quat="1 0 0 0">
+      <inertial pos="0.061841 -0.006460 -0.032998" mass="1.002455" diaginertia="1.725911e-3 2.065984e-3 2.042959e-3"/>
       <geom type="mesh" mesh="hand_base_link_0" material="72,71,61"/>
       <geom type="mesh" mesh="hand_base_link_1" material="64,64,64"/>
       <geom type="mesh" mesh="hand_base_link_2" material="219,219,219"/>

--- a/robots/hand_v4/hand_v4_with_sphere.xml
+++ b/robots/hand_v4/hand_v4_with_sphere.xml
@@ -62,6 +62,7 @@
     </body>
 
     <body name="hand/base_link" childclass="hand" pos="0 0 0.5" quat="0.9961947 0 0.0871557 0">
+      <inertial pos="0.061841 -0.006460 -0.032998" mass="1.002455" diaginertia="1.725911e-3 2.065984e-3 2.042959e-3"/>
       <geom type="mesh" mesh="hand_base_link_0" material="72,71,61"/>
       <geom type="mesh" mesh="hand_base_link_1" material="64,64,64"/>
       <geom type="mesh" mesh="hand_base_link_2" material="219,219,219"/>

--- a/robots/torobo2/torobo2_with_hand.xml
+++ b/robots/torobo2/torobo2_with_hand.xml
@@ -205,7 +205,7 @@
                               <geom class="visual" type="mesh" mesh="left_arm_link6" material="219,219,219"/>
                               <geom class="collision" type="mesh" mesh="left_arm_link6_collision"/>
                               <body name="left_arm/link_7" pos="0 0.048 0.01" quat="0.707107 0.707107 0 0">
-                                <inertial pos="0.00017 2.7e-05 0.01376" quat="0.52141 0.478267 -0.520329 0.478174" mass="0.14265" diaginertia="7.31843e-05 5.09235e-05 4.92308e-05"/>
+                                <inertial pos="0.0859563 -0.00499509 0.0282954" quat="0.175962 0.574633 0.0859168 0.79464" mass="1.29577" diaginertia="0.0049482 0.00472867 0.00170521"/>
                                 <joint name="left_arm/joint_7" pos="0 0 0" axis="0 0 1" range="-0.349066 1.5708"/>
                                 <geom class="visual" type="mesh" mesh="left_arm_link7" material="72,71,61"/>
                                 <geom class="collision" type="mesh" mesh="left_arm_link7_collision"/>
@@ -345,7 +345,7 @@
                               <geom class="visual" type="mesh" mesh="right_arm_link6"  material="219,219,219"/>
                               <geom class="collision" type="mesh" mesh="right_arm_link6_collision"/>
                               <body name="right_arm/link_7" pos="0 0.048 -0.01" quat="0.707107 -0.707107 0 0">
-                                <inertial pos="0.00017 -2.7e-05 -0.01376" quat="0.478174 0.520329 -0.478267 0.52141" mass="0.14265" diaginertia="7.31843e-05 5.09235e-05 4.92308e-05"/>
+                                <inertial pos="0.0859562 -0.00500099 -0.0282955" quat="-0.0859549 0.794654 -0.175903 0.574627" mass="1.29577" diaginertia="0.0049481 0.00472861 0.00170517"/>
                                 <joint name="right_arm/joint_7" pos="0 0 0" axis="0 0 1" range="-0.349066 1.5708"/>
                                 <geom class="visual" type="mesh" mesh="right_arm_link7"  material="72,71,61"/>
                                 <geom class="collision" type="mesh" mesh="right_arm_link7_collision"/>


### PR DESCRIPTION
Add missed hand_base_link inertia to HandV4 and the hand model in Torobo2.
I guess the inertia of the root link for non-floating base robots is not output when converting from urdf to xml.